### PR TITLE
Replace xdg with directories to allow libcosmic to run on other platforms.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ image = {version = "0.24.1", optional = true }
 float-cmp = { version = "0.9.0", optional = true }
 serde = { version = "1.0.129", features = ["derive"] }
 ron = "0.8"
-xdg = "2.4.1"
 lazy_static = "1.4.0"
 csscolorparser = {version = "0.6.2", features = ["serde"]}
+directories = { git = "https://github.com/edfloreshz/directories-rs", version = "4.0.1" }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ use std::{
     io::{prelude::*, BufReader},
     path::PathBuf,
 };
-use directories::ext::{ProjectDirsExt, BaseDirsExt};
+use directories::{ProjectDirsExt, BaseDirsExt};
 
 /// Cosmic Theme config
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0-only
 
 use crate::{util::CssColor, Theme, NAME, THEME_DIR};
-use anyhow::{bail, Result};
+use anyhow::{bail, Result, Context};
 use palette::Srgba;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -10,6 +10,7 @@ use std::{
     io::{prelude::*, BufReader},
     path::PathBuf,
 };
+use directories::ext::{ProjectDirsExt, BaseDirsExt};
 
 /// Cosmic Theme config
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -52,7 +53,7 @@ impl Config {
 
     /// save the cosmic theme config
     pub fn save(&self) -> Result<()> {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix(NAME)?;
+        let xdg_dirs = directories::ProjectDirs::from_path(PathBuf::from(NAME)).context("Failed to find project directory.")?;
         if let Ok(path) = xdg_dirs.place_config_file(PathBuf::from(format!("{CONFIG_NAME}.ron"))) {
             let mut f = File::create(path)?;
             let ron = ron::ser::to_string_pretty(&self, Default::default())?;
@@ -65,7 +66,7 @@ impl Config {
 
     /// init the config directory
     pub fn init() -> anyhow::Result<PathBuf> {
-        let base_dirs = xdg::BaseDirectories::new()?;
+        let base_dirs = directories::BaseDirs::new().context("Failed to get base directories.")?;
         let res = Ok(base_dirs.create_config_directory(NAME)?);
         Theme::<Srgba>::init()?;
 
@@ -81,8 +82,8 @@ impl Config {
 
     /// load the cosmic theme config
     pub fn load() -> Result<Self> {
-        let xdg_dirs = xdg::BaseDirectories::with_prefix(NAME)?;
-        let path = xdg_dirs.get_config_home();
+        let xdg_dirs = directories::ProjectDirs::from_path(PathBuf::from(NAME)).context("Failed to find project directory.")?;
+        let path = xdg_dirs.config_dir();
         std::fs::create_dir_all(&path)?;
         let path = xdg_dirs.find_config_file(PathBuf::from(format!("{CONFIG_NAME}.ron")));
         if path.is_none() {
@@ -124,7 +125,7 @@ impl Config {
             _ => anyhow::bail!("No configured active overrides"),
         };
         let css_path: PathBuf = [NAME, THEME_DIR].iter().collect();
-        let css_dirs = xdg::BaseDirectories::with_prefix(css_path)?;
+        let css_dirs = directories::ProjectDirs::from_path(PathBuf::from(css_path)).context("Failed to find project directory.")?;
         let active_theme_path = match css_dirs.find_data_file(format!("{active}.ron")) {
             Some(p) => p,
             _ => anyhow::bail!("Could not find theme"),

--- a/src/model/cosmic_palette.rs
+++ b/src/model/cosmic_palette.rs
@@ -5,9 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::Context;
 use lazy_static::lazy_static;
 use palette::Srgba;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use directories::{BaseDirsExt, ProjectDirsExt};
 
 use crate::{util::CssColor, NAME, PALETTE_DIR};
 
@@ -161,7 +163,7 @@ where
     /// save the theme to the theme directory
     pub fn save(&self) -> anyhow::Result<()> {
         let ron_path: PathBuf = [NAME, PALETTE_DIR].iter().collect();
-        let ron_dirs = xdg::BaseDirectories::with_prefix(ron_path)?;
+        let ron_dirs = directories::ProjectDirs::from_path(ron_path).context("Failed to get project directories.")?;
         let ron_name = format!("{}.ron", self.name());
 
         if let Ok(p) = ron_dirs.place_config_file(ron_name) {
@@ -176,14 +178,14 @@ where
     /// init the theme directory
     pub fn init() -> anyhow::Result<PathBuf> {
         let ron_path: PathBuf = [NAME, PALETTE_DIR].iter().collect();
-        let base_dirs = xdg::BaseDirectories::new()?;
+        let base_dirs = directories::BaseDirs::new().context("Failed to get base directories.")?;
         Ok(base_dirs.create_config_directory(ron_path)?)
     }
 
     /// load a theme by name
     pub fn load_from_name(name: &str) -> anyhow::Result<Self> {
         let ron_path: PathBuf = [NAME, PALETTE_DIR].iter().collect();
-        let ron_dirs = xdg::BaseDirectories::with_prefix(ron_path)?;
+        let ron_dirs = directories::ProjectDirs::from_path(ron_path).context("Failed to get project directories.")?;
 
         let ron_name = format!("{}.ron", name);
         if let Some(p) = ron_dirs.find_config_file(ron_name) {

--- a/src/model/theme.rs
+++ b/src/model/theme.rs
@@ -4,6 +4,7 @@ use crate::{
     util::CssColor, Component, ComponentType, Container, ContainerType, CosmicPalette,
     DARK_PALETTE, LIGHT_PALETTE, NAME, THEME_DIR,
 };
+use anyhow::Context;
 use palette::Srgba;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
@@ -12,6 +13,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
+use directories::{BaseDirsExt, ProjectDirsExt};
 
 /// Cosmic Theme data structure with all colors and its name
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -75,7 +77,7 @@ where
     /// save the theme to the theme directory
     pub fn save(&self) -> anyhow::Result<()> {
         let ron_path: PathBuf = [NAME, THEME_DIR].iter().collect();
-        let ron_dirs = xdg::BaseDirectories::with_prefix(ron_path)?;
+        let ron_dirs = directories::ProjectDirs::from_path(ron_path).context("Failed to get project directories.")?;
         let ron_name = format!("{}.ron", &self.name);
 
         if let Ok(p) = ron_dirs.place_config_file(ron_name) {
@@ -90,14 +92,14 @@ where
     /// init the theme directory
     pub fn init() -> anyhow::Result<PathBuf> {
         let ron_path: PathBuf = [NAME, THEME_DIR].iter().collect();
-        let base_dirs = xdg::BaseDirectories::new()?;
+        let base_dirs = directories::BaseDirs::new().context("Failed to get base directories.")?;
         Ok(base_dirs.create_config_directory(ron_path)?)
     }
 
     /// load a theme by name
     pub fn load_from_name(name: &str) -> anyhow::Result<Self> {
         let ron_path: PathBuf = [NAME, THEME_DIR].iter().collect();
-        let ron_dirs = xdg::BaseDirectories::with_prefix(ron_path)?;
+        let ron_dirs = directories::ProjectDirs::from_path(ron_path).context("Failed to get project directories.")?;
 
         let ron_name = format!("{}.ron", name);
         if let Some(p) = ron_dirs.find_config_file(ron_name) {


### PR DESCRIPTION
- Removed `xdg` crate to make it compatible with Windows and macOS.
- Added `directories` crate with helper functions implemented.